### PR TITLE
Fix dynamic classes and cleanup components

### DIFF
--- a/src/components/DiscordStrip.tsx
+++ b/src/components/DiscordStrip.tsx
@@ -1,6 +1,7 @@
 import { FaDiscord } from "react-icons/fa";
 
-export default function FloatingDiscord() {
+// Floating Discord link that stays fixed in the bottom corner
+export default function DiscordStrip() {
   return (
     <a
       href="https://discord.gg/PqgWZS7XeX"

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -13,10 +13,28 @@ export default function PageLayout({
   columns = 3,
   gap = "gap-6",
 }: PageLayoutProps) {
+  // Tailwind's JIT won't detect classes built from dynamic strings, so map
+  // supported values to explicit class names.
+  const columnClasses: Record<number, string> = {
+    1: "md:grid-cols-1",
+    2: "md:grid-cols-2",
+    3: "md:grid-cols-3",
+    4: "md:grid-cols-4",
+  };
+
+  const gapClasses: Record<string, string> = {
+    "gap-2": "gap-2",
+    "gap-4": "gap-4",
+    "gap-6": "gap-6",
+    "gap-8": "gap-8",
+  };
+
   const layoutClasses =
     layout === "grid"
-      ? `grid grid-cols-1 md:grid-cols-${columns} ${gap}`
-      : `flex flex-wrap ${gap}`;
+      ? `grid grid-cols-1 ${columnClasses[columns] || columnClasses[3]} ${
+          gapClasses[gap] || gapClasses["gap-6"]
+        }`
+      : `flex flex-wrap ${gapClasses[gap] || gapClasses["gap-6"]}`;
 
   return (
     <div className={`max-w-7xl mx-auto px-6 py-12 ${layoutClasses} ${className}`}>

--- a/src/components/ScrollReveal.tsx
+++ b/src/components/ScrollReveal.tsx
@@ -23,7 +23,7 @@ export default function ScrollReveal({
   });
 
   useEffect(() => {
-    console.log("In view:", inView); // Debug log
+    // Start the reveal animation once the element is in view
     if (inView) {
       controls.start({ opacity: 1, y: 0 });
     }


### PR DESCRIPTION
## Summary
- ensure scroll reveal effect doesn't spam console
- rename DiscordStrip component for clarity
- generate Tailwind classes without dynamic strings

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68476a018a3883298e3ad7a35b9c4ca4