### PR TITLE
Improve background styles and clean CSS

### DIFF
--- a/src/hooks/useParallax.ts
+++ b/src/hooks/useParallax.ts
@@ -10,7 +10,7 @@ export function useParallax(speed: number) {
   // Track the current offset value
   const [offsetY, setOffsetY] = useState(0);
   // Store the animation frame id so it can be cancelled on unmount
-  const frame = useRef<number>();
+  const frame = useRef<number>(0);
 
   useEffect(() => {
     const handleScroll = () => {

--- a/src/index.css
+++ b/src/index.css
@@ -376,3 +376,8 @@ footer a:hover {
 .animate-text-fill:hover {
   animation: textFill 1s ease-in-out infinite;
 }
+
+/* Generic page background */
+.page-bg {
+  @apply bg-fixed bg-cover bg-center;
+}

--- a/src/pages/Community.tsx
+++ b/src/pages/Community.tsx
@@ -1,6 +1,5 @@
 import NavBar from "../components/NavBar"; // Import NavBar
 import Section from "../components/Section";
-import "../styles/Community.css"; // Correct the path if necessary
 import PageLayout from "../components/PageLayout";
 import FramedPanel from "../components/FramedPanel";
 import Divider from "../components/Divider";
@@ -12,7 +11,9 @@ import { FaTwitter, FaYoutube, FaInstagram } from "react-icons/fa"; // Import so
 /** Hub for links to community resources and social channels */
 export default function Community() {
   return (
-    <div className="relative min-h-screen bg-black text-white font-gothic community-bg">
+    <div
+      className="relative min-h-screen bg-black text-white font-gothic page-bg bg-[url('/assets/community-bg.png')]"
+    >
       {/* ☠ NavBar */}
       <NavBar />
 

--- a/src/pages/Devlog.tsx
+++ b/src/pages/Devlog.tsx
@@ -10,7 +10,6 @@ import Section from "../components/Section";
 import PageLayout from "../components/PageLayout";
 import FramedPanel from "../components/FramedPanel";
 import Divider from "../components/Divider";
-import "../styles/Devlog.css"; // Import the CSS file
 
 /** Developer diary with expandable markdown posts */
 export default function Devlog() {
@@ -39,7 +38,9 @@ export default function Devlog() {
   }, []);
 
   return (
-    <div className="relative min-h-screen bg-black overflow-hidden font-gothic text-white devlog-bg">
+    <div
+      className="relative min-h-screen bg-black overflow-hidden font-gothic text-white page-bg bg-[url('/assets/devlog-bg.png')]"
+    >
       {/* ☠ NavBar */}
       <NavBar />
 

--- a/src/pages/Games.tsx
+++ b/src/pages/Games.tsx
@@ -4,7 +4,6 @@ import PageLayout from "../components/PageLayout";
 import FramedPanel from "../components/FramedPanel";
 //import Divider from "../components/Divider";
 import Footer from "../components/Footer";
-import "../styles/Games.css"; // Ensure the CSS file is imported
 
 /** List of published and upcoming titles */
 export default function Games() {
@@ -36,7 +35,9 @@ export default function Games() {
   ];
 
   return (
-    <div className="relative min-h-screen bg-black text-white font-gothic games-bg">
+    <div
+      className="relative min-h-screen bg-black text-white font-gothic page-bg bg-[url('/assets/games-bg.png')]"
+    >
       {/* ☠ NavBar */}
       <NavBar />
 

--- a/src/styles/Community.css
+++ b/src/styles/Community.css
@@ -1,5 +1,0 @@
-/* 🌐 Community Page Background */
-.community-bg {
-    background: url('/assets/community-bg.png') center center / cover no-repeat;
-    background-attachment: fixed; /* Optional: Makes the background fixed during scrolling */
-  }

--- a/src/styles/Devlog.css
+++ b/src/styles/Devlog.css
@@ -1,5 +1,0 @@
-/* 🌐 Devlog Page Background */
-.devlog-bg {
-    background: url('/assets/devlog-bg.png') center center / cover no-repeat;
-    background-attachment: fixed; /* Optional: Makes the background fixed during scrolling */
-  }

--- a/src/styles/Games.css
+++ b/src/styles/Games.css
@@ -1,5 +1,0 @@
-/* 🌌 Games Page Background */
-.games-bg {
-  background: url('/assets/games-bg.png') center center / cover no-repeat;
-  background-attachment: fixed; /* Optional: Makes the background fixed during scrolling */
-}


### PR DESCRIPTION
## Summary
- remove unused truncated CSS files
- create a reusable `.page-bg` class for fixed page backgrounds
- use Tailwind background utilities on Community, Devlog and Games pages
- fix `useParallax` TypeScript error

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68647f7585a88329a0d1c646cfeb43dd