### PR TITLE
Improve spacing and contrast

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,7 +3,7 @@ import { FaDiscord, FaYoutube, FaTwitter, FaInstagram, FaFacebook, FaTiktok, FaT
 
 export default function Footer() {
   return (
-    <footer className="relative z-10 bg-gradient-to-b from-black to-gray-900 border-t border-red-900 text-gray-400 px-6 py-10 font-gothic">
+    <footer className="relative z-10 bg-gradient-to-b from-black to-gray-900 border-t border-red-900 text-gray-300 px-6 py-10 font-gothic">
       <div className="max-w-7xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-8">
 
         {/* Logo / Title */}
@@ -11,7 +11,7 @@ export default function Footer() {
           <h2 className="text-3xl text-red-700 font-bold drop-shadow-[0_0_10px_rgba(255,0,0,0.7)]">
             Crypthouse Studio
           </h2>
-          <p className="mt-2 text-sm text-gray-500">
+          <p className="mt-2 text-sm text-gray-300">
             Born in the shadows of the grave.
           </p>
         </div>
@@ -34,8 +34,8 @@ export default function Footer() {
 
         {/* Social Links */}
         <div className="flex flex-col items-center md:items-end gap-4">
-          <p className="text-sm text-gray-500">Follow Us</p>
-          <div className="flex gap-4 text-2xl text-gray-400">
+          <p className="text-sm text-gray-300">Follow Us</p>
+          <div className="flex gap-4 text-2xl text-gray-300">
             <a
               href="https://discord.gg/PqgWZS7XeX"
               target="_blank"
@@ -107,7 +107,7 @@ export default function Footer() {
       <div className="my-8 border-t border-gray-700"></div>
 
       {/* Back to Top and Copyright */}
-      <div className="flex flex-col md:flex-row justify-between items-center text-center text-sm text-gray-500">
+      <div className="flex flex-col md:flex-row justify-between items-center text-center text-sm text-gray-300">
         <button
           onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
           className="text-red-500 hover:text-red-700 transition-all duration-300 mb-4 md:mb-0"

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -11,7 +11,7 @@ export default function PageLayout({
   className = "",
   layout = "grid",
   columns = 3,
-  gap = "gap-6",
+  gap = "gap-8",
 }: PageLayoutProps) {
   // Tailwind's JIT won't detect classes built from dynamic strings,
   // so map supported values to explicit class names.
@@ -27,15 +27,17 @@ export default function PageLayout({
     "gap-4": "gap-4",
     "gap-6": "gap-6",
     "gap-8": "gap-8",
+    "gap-10": "gap-10",
+    "gap-12": "gap-12",
   };
 
   // Build the set of utility classes based on the chosen layout.
   const layoutClasses =
     layout === "grid"
       ? `grid grid-cols-1 ${columnClasses[columns] || columnClasses[3]} ${
-          gapClasses[gap] || gapClasses["gap-6"]
+          gapClasses[gap] || gapClasses["gap-8"]
         }`
-      : `flex flex-wrap ${gapClasses[gap] || gapClasses["gap-6"]}`;
+      : `flex flex-wrap ${gapClasses[gap] || gapClasses["gap-8"]}`;
 
   return (
     <>
@@ -43,7 +45,7 @@ export default function PageLayout({
         A simple container that centers content and applies either a grid
         or flex layout depending on props.
       */}
-      <div className={`max-w-7xl mx-auto px-6 py-12 ${layoutClasses} ${className}`}> 
+      <div className={`max-w-7xl mx-auto px-6 py-16 ${layoutClasses} ${className}`}> 
         {children}
       </div>
     </>

--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -17,7 +17,7 @@ export default function Section({
   children,
   className = "",
   background,
-  padding = "py-16",
+  padding = "py-24",
   alignment = "center",
   style,
 }: SectionProps) {

--- a/src/pages/Devlog.tsx
+++ b/src/pages/Devlog.tsx
@@ -86,7 +86,7 @@ export default function Devlog() {
                 <h2 className="text-red-700 font-bold text-xl">
                   {post.id.replace(/-/g, " ")}
                 </h2>
-                <p className="text-gray-400 text-sm italic">May 1, 2025</p>
+                <p className="text-gray-300 text-sm italic">May 1, 2025</p>
               </div>
 
               {/* Expandable Content */}


### PR DESCRIPTION
## Summary
- expand default padding in `Section` components for better breathing room
- bump gaps and spacing in `PageLayout`
- improve footer text contrast
- lighten devlog date styling

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6864898fed7c8329a0515c854fe27786