### PR TITLE
Add front-matter support to devlog posts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@react-three/drei": "^10.0.7",
         "@react-three/fiber": "^9.1.2",
         "aos": "^2.3.4",
+        "buffer": "^6.0.3",
         "classnames": "^2.5.1",
         "framer-motion": "^12.10.0",
         "gray-matter": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@react-three/drei": "^10.0.7",
     "@react-three/fiber": "^9.1.2",
     "aos": "^2.3.4",
+    "buffer": "^6.0.3",
     "classnames": "^2.5.1",
     "framer-motion": "^12.10.0",
     "gray-matter": "^4.0.3",

--- a/src/devlog/game-world-expansion.md
+++ b/src/devlog/game-world-expansion.md
@@ -1,6 +1,7 @@
 ---
 title: "Game World Expansion: A New Frontier Awaits"
 date: "2025-05-07"
+description: "An overview of our largest update introducing new regions, mystical creatures, and gear."
 ---
 # 🌍 Game World Expansion: A New Frontier Awaits
 ---

--- a/src/devlog/introducing-crypthouse-studio.md
+++ b/src/devlog/introducing-crypthouse-studio.md
@@ -1,7 +1,9 @@
+---
+title: "Introducing Crypthouse Studio"
+date: "2025-05-01"
+description: "Welcome to Crypthouse Studio, where we craft immersive gothic experiences born from the shadows of the grave."
+---
 # 🏰 Introducing Crypthouse Studio
-
-**📅 Date:** *May 1, 2025*
-
 ---
 
 Welcome to **Crypthouse Studio**, where we craft immersive gothic experiences born from the shadows of the grave. Our mission is to create games that are haunting, memorable, and resonate deeply with players.

--- a/src/pages/Devlog.tsx
+++ b/src/pages/Devlog.tsx
@@ -1,5 +1,11 @@
 import { useEffect, useState } from "react";
 import matter from "gray-matter";
+// Polyfill Node's Buffer for gray-matter in the browser
+import { Buffer } from "buffer";
+
+if (typeof globalThis !== "undefined" && !(globalThis as Record<string, unknown>).Buffer) {
+  (globalThis as Record<string, unknown>).Buffer = Buffer;
+}
 import AOS from "aos";
 import "aos/dist/aos.css";
 import ReactMarkdown from "react-markdown";


### PR DESCRIPTION
## Summary
- add YAML metadata to devlog markdown posts
- parse front-matter when loading posts
- display parsed title, date, and description

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6864914163ac8329bd61acba87592af9